### PR TITLE
Avoid $undoStack being reset after setValue

### DIFF
--- a/src/brace-diff.js
+++ b/src/brace-diff.js
@@ -353,7 +353,7 @@ function copy(acediff, e, dir)
 
     // keep track of the scroll height
     var h = targetEditor.ace.getSession().getScrollTop();
-    targetEditor.ace.getSession().setValue(startContent + contentToInsert + endContent);
+    targetEditor.ace.getSession().doc.setValue(startContent + contentToInsert + endContent);
     targetEditor.ace.getSession().setScrollTop(parseInt(h));
 
     acediff.diff();


### PR DESCRIPTION
There's an issue inherited from original ace-diff that you can't undo/redo after applying patch using gutter's arrows. This PR fix that.
